### PR TITLE
Remove dependency graph update step from CI

### DIFF
--- a/.github/workflows/backend-maven-ci.yml
+++ b/.github/workflows/backend-maven-ci.yml
@@ -29,7 +29,3 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file backend/pom.xml
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
Removed the optional step to update the dependency graph in the CI workflow.