### PR TITLE
Fix channel endpoint path and update mapper annotation

### DIFF
--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/ChannelController.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/ChannelController.java
@@ -69,7 +69,7 @@ public class ChannelController extends BaseController {
 	@OrganizationHeader
 	@Operation(summary = "Get a channel by ID")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Found the channel") })
-	@GetMapping("/channels/{channelId}")
+	@GetMapping("/channels/{id}")
 	public ResponseEntity<ChannelResponse> getChannel(@PathVariable UUID id) {
 		var command = ChannelFetchCommand.builder()
 				.channelId(HUID.fromUUID(id))

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/mapper/ChannelsBatchFetchMapper.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/mapper/ChannelsBatchFetchMapper.java
@@ -10,7 +10,7 @@ import software.blacknode.backend.api.controller.mapper.impl.ResponseMapper;
 import software.blacknode.backend.application.channel.command.ChannelsBatchFetchCommand;
 import software.blacknode.backend.application.channel.usecase.ChannelsBatchFetchUseCase;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface ChannelsBatchFetchMapper extends RequestMapper<ChannelsBatchFetchRequest, ChannelsBatchFetchCommand>, ResponseMapper<ChannelsBatchFetchUseCase.Result, ChannelsBatchFetchResponse> {
 
 	@Override


### PR DESCRIPTION
Changed the channel fetch endpoint from '/channels/{channelId}' to '/channels/{id}' in ChannelController for consistency. Updated ChannelsBatchFetchMapper to use '@Mapper(componentModel = "spring")' to enable Spring integration.