### PR TITLE
Implement infrastructure for Member entity persistence

### DIFF
--- a/backend/blacknode-software-backend-api/src/main/resources/application.yml
+++ b/backend/blacknode-software-backend-api/src/main/resources/application.yml
@@ -20,12 +20,12 @@ jwt:
   secret: "f0KeSbOwDytCaVKhPKqaBOkFM7t80hMc6mGVIArVJdI="
   
 logging:
-  level:
-    org.hibernate: TRACE
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type.descriptor.sql: TRACE
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.type.descriptor.converter: TRACE
-    org.hibernate.metamodel.model.convert: TRACE
-    org.springframework.orm.jpa: DEBUG
-    org.springframework.transaction: TRACE
+  # level:
+  #  org.hibernate: TRACE
+  #  org.hibernate.SQL: DEBUG
+  #  org.hibernate.type.descriptor.sql: TRACE
+  #  org.hibernate.orm.jdbc.bind: TRACE
+  #  org.hibernate.type.descriptor.converter: TRACE
+  #  org.hibernate.metamodel.model.convert: TRACE
+  #  org.springframework.orm.jpa: DEBUG
+  #  org.springframework.transaction: TRACE

--- a/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/Member.java
+++ b/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/Member.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import me.hinsinger.hinz.common.huid.HUID;
 import me.hinsinger.hinz.common.time.timestamp.Timestamp;
+import software.blacknode.backend.domain.entity.DomainEntity;
 import software.blacknode.backend.domain.entity.modifier.impl.create.Creatable;
 import software.blacknode.backend.domain.entity.modifier.impl.create.meta.CreationMeta;
 import software.blacknode.backend.domain.entity.modifier.impl.delete.Deletable;
@@ -22,7 +23,7 @@ import software.blacknode.backend.domain.member.meta.modify.MemberModificationMe
 
 @Builder
 @AllArgsConstructor(onConstructor = @__({ @Deprecated }))
-public class Member implements Creatable, Modifiable, Deletable {
+public class Member implements DomainEntity, Creatable, Modifiable, Deletable {
 
 	@Getter private HUID id;
 	

--- a/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/repository/MemberRepository.java
+++ b/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/repository/MemberRepository.java
@@ -10,9 +10,9 @@ public interface MemberRepository {
 
 	Optional<Member> findById(HUID organizationId, HUID id);
 	
-	List<Member> findAllById(HUID organizationId, List<HUID> ids);
+	List<Member> findByIds(HUID organizationId, List<HUID> ids);
 	
-	List<Member> findAllInOrganization(HUID organizationId);
+	List<Member> findByOrganizationId(HUID organizationId);
 
 	Optional<Member> findByAccountId(HUID organizationId, HUID accountId);
 	

--- a/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/MemberRepositoryImpl.java
+++ b/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/MemberRepositoryImpl.java
@@ -5,41 +5,85 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import lombok.RequiredArgsConstructor;
 import me.hinsinger.hinz.common.huid.HUID;
 import software.blacknode.backend.domain.member.Member;
 import software.blacknode.backend.domain.member.repository.MemberRepository;
+import software.blacknode.backend.infrastructure.entity.state.EntityState;
+import software.blacknode.backend.infrastructure.member.entity.MemberEntity;
+import software.blacknode.backend.infrastructure.member.entity.mapper.MemberEntityMapper;
+import software.blacknode.backend.infrastructure.member.entity.repository.MemberEntityRepository;
+import software.blacknode.backend.infrastructure.organization.related.repository.OrganizationRelatedEntityRepository;
 
 @Repository
-public class MemberRepositoryImpl implements MemberRepository {
-
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository, OrganizationRelatedEntityRepository<Member, MemberEntity> {
+	
+	private final MemberEntityRepository repository;
+	private final MemberEntityMapper mapper;
+	
 	@Override
 	public Optional<Member> findById(HUID organizationId, HUID id) {
-		// TODO Auto-generated method stub
-		return Optional.empty();
+		var member = repository.queryByIdAndOrganizationIdAndState(
+				organizationId.toUUID(),
+				id.toUUID(),
+				EntityState.ACTIVE
+			);
+	
+		return member.map(this::toDomainEntity);	
 	}
 
 	@Override
-	public List<Member> findAllById(HUID organizationId, List<HUID> ids) {
-		// TODO Auto-generated method stub
-		return null;
+	public List<Member> findByIds(HUID organizationId, List<HUID> ids) {
+		var uuidIds = ids.stream().map(HUID::toUUID).toList();
+		
+		var members = repository.queryAllByIdInOrganizationIdAndState(
+				organizationId.toUUID(),
+				uuidIds,
+				EntityState.ACTIVE
+			);
+		
+		return members.stream().map(this::toDomainEntity).toList();
 	}
 
 	@Override
-	public List<Member> findAllInOrganization(HUID organizationId) {
-		// TODO Auto-generated method stub
-		return null;
+	public List<Member> findByOrganizationId(HUID organizationId) {
+		var members = repository.queryByOrganizationIdAndState(
+				organizationId.toUUID(),
+				EntityState.ACTIVE
+			);
+		
+		return members.stream().map(this::toDomainEntity).toList();
 	}
 
 	@Override
 	public Optional<Member> findByAccountId(HUID organizationId, HUID accountId) {
-		// TODO Auto-generated method stub
-		return Optional.empty();
+		var member = repository.queryByOrganizationIdAndAccountIdAndState(
+				organizationId.toUUID(),
+				accountId.toUUID(),
+				EntityState.ACTIVE
+			);
+		
+		return member.map(this::toDomainEntity);
 	}
 
 	@Override
 	public void save(HUID organizationId, Member member) {
-		// TODO Auto-generated method stub
+		member.ensureBelongsToOrganization(organizationId);
 		
+		var memberEntity = toInfrastructureEntity(member);
+		
+		repository.save(memberEntity);
+	}
+
+	@Override
+	public MemberEntity toInfrastructureEntity(Member domainEntity) {
+		return mapper.toInfrastructureEntity(domainEntity);
+	}
+
+	@Override
+	public Member toDomainEntity(MemberEntity infrastructureEntity) {
+		return mapper.toDomainEntity(infrastructureEntity);
 	}
 
 

--- a/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/MemberEntity.java
+++ b/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/MemberEntity.java
@@ -1,0 +1,47 @@
+package software.blacknode.backend.infrastructure.member.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import software.blacknode.backend.infrastructure.entity.version.annotation.VersionedEntity;
+import software.blacknode.backend.infrastructure.member.entity.meta.MemberEntityMeta;
+import software.blacknode.backend.infrastructure.organization.related.OrganizationRelatedEntity;
+
+@Getter
+@Entity
+@SuperBuilder
+@Table(name = "members")
+@Access(AccessType.FIELD)
+@NoArgsConstructor
+@ToString 
+public class MemberEntity extends OrganizationRelatedEntity {
+
+	@NotNull
+	@Column(name = "meta")
+	@VersionedEntity
+	private MemberEntityMeta meta;
+	
+	@NotNull
+	@Column(name = "account_id")
+	private UUID accountId;
+	
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+	
+	@Column(name = "modified_at")
+	private Instant modifiedAt;
+	
+	@Column(name = "deleted_at")
+	private Instant deletedAt;
+	
+}

--- a/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/mapper/MemberEntityMapper.java
+++ b/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/mapper/MemberEntityMapper.java
@@ -1,0 +1,49 @@
+package software.blacknode.backend.infrastructure.member.entity.mapper;
+
+import org.mapstruct.Mapper;
+
+import software.blacknode.backend.domain.member.Member;
+import software.blacknode.backend.domain.member.meta.MemberMeta;
+import software.blacknode.backend.infrastructure.entity.mapper.InfrastructureMapper;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.domain.CreationMappingDomain;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.domain.DeletionMappingDomain;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.domain.IdMappingDomain;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.domain.ModificationMappingDomain;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.domain.OrganizationIdMappingDomain;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.CreationMappingInfrastructure;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.DeletionMappingInfrastructure;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.IdMappingInfrastructure;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.ModificationMappingInfrastructure;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.OrganizationIdMappingInfrastructure;
+import software.blacknode.backend.infrastructure.entity.mapper.annotation.infrastructure.StateMappingInfrastructure;
+import software.blacknode.backend.infrastructure.member.entity.MemberEntity;
+import software.blacknode.backend.infrastructure.member.entity.meta.MemberEntityMeta;
+
+@Mapper(componentModel = "spring")
+public interface MemberEntityMapper extends InfrastructureMapper<Member, MemberEntity> {
+
+	@Override
+	@IdMappingInfrastructure
+	@OrganizationIdMappingInfrastructure
+	
+	@CreationMappingInfrastructure
+	@ModificationMappingInfrastructure
+	@DeletionMappingInfrastructure
+	
+	@StateMappingInfrastructure
+	MemberEntity toInfrastructureEntity(Member domain);
+	
+	@Override
+	@IdMappingDomain
+	@OrganizationIdMappingDomain
+	
+	@CreationMappingDomain
+	@ModificationMappingDomain
+	@DeletionMappingDomain
+	Member toDomainEntity(MemberEntity entity);
+	
+	MemberEntityMeta map(MemberMeta meta);
+	
+	MemberMeta map(MemberEntityMeta meta);
+	
+}

--- a/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/meta/MemberEntityMeta.java
+++ b/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/meta/MemberEntityMeta.java
@@ -1,0 +1,17 @@
+package software.blacknode.backend.infrastructure.member.entity.meta;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import software.blacknode.backend.infrastructure.entity.version.VersionableEntity;
+import software.blacknode.backend.infrastructure.entity.version.annotation.VersionedEntity;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@VersionedEntity
+@ToString
+public class MemberEntityMeta implements VersionableEntity {
+	
+}

--- a/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/repository/MemberEntityRepository.java
+++ b/backend/blacknode-software-backend-infrastructure/src/main/java/software/blacknode/backend/infrastructure/member/entity/repository/MemberEntityRepository.java
@@ -1,0 +1,27 @@
+package software.blacknode.backend.infrastructure.member.entity.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import software.blacknode.backend.infrastructure.entity.state.EntityState;
+import software.blacknode.backend.infrastructure.member.entity.MemberEntity;
+
+public interface MemberEntityRepository extends JpaRepository<MemberEntity, UUID> {
+
+	@Query("SELECT m FROM MemberEntity m WHERE m.organizationId = :organizationId AND m.id = :id AND m.state = :state")
+	Optional<MemberEntity> queryByIdAndOrganizationIdAndState(@Param("organizationId") UUID organizationId, @Param("id") UUID id, @Param("state") EntityState state);
+
+	@Query("SELECT m FROM MemberEntity m WHERE m.organizationId = :organizationId AND m.state = :state")
+	List<MemberEntity> queryByOrganizationIdAndState(@Param("organizationId") UUID organizationId, @Param("state") EntityState state);
+	
+	@Query("SELECT m FROM MemberEntity m WHERE m.organizationId = :organizationId AND m.id IN :ids AND m.state = :state")
+	List<MemberEntity> queryAllByIdInOrganizationIdAndState(@Param("organizationId") UUID organizationId, @Param("ids") List<UUID> ids, @Param("state") EntityState state);
+	
+	@Query("SELECT m FROM MemberEntity m WHERE m.organizationId = :organizationId AND m.accountId = :accountId AND m.state = :state")
+	Optional<MemberEntity> queryByOrganizationIdAndAccountIdAndState(@Param("organizationId") UUID organizationId, @Param("accountId") UUID accountId, @Param("state") EntityState state);
+}


### PR DESCRIPTION
Introduces MemberEntity, MemberEntityMeta, MemberEntityMapper, and MemberEntityRepository for JPA-based persistence of Member domain objects. Updates MemberRepository and MemberRepositoryImpl to use the new infrastructure, including mapping and repository methods. Also comments out detailed Hibernate logging in application.yml.