### PR TITLE
Member deletion logic and fixes

### DIFF
--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/account/request/AccountPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/account/request/AccountPatchRequest.java
@@ -2,10 +2,12 @@ package software.blacknode.backend.api.controller.account.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
 @AllArgsConstructor
+@ToString
 public class AccountPatchRequest extends PatchRequest {
 
 	private String firstName;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/auth/request/AuthenticateWithPasswordRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/auth/request/AuthenticateWithPasswordRequest.java
@@ -1,10 +1,12 @@
 package software.blacknode.backend.api.controller.auth.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
+@AllArgsConstructor
 @ToString
 public class AuthenticateWithPasswordRequest extends BaseRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelCreateRequest.java
@@ -1,11 +1,14 @@
 package software.blacknode.backend.api.controller.channel.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ChannelCreateRequest extends BaseRequest {
 
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelPatchRequest.java
@@ -1,11 +1,14 @@
 package software.blacknode.backend.api.controller.channel.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ChannelPatchRequest extends PatchRequest {
 
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelsBatchFetchRequest.java
@@ -1,7 +1,13 @@
 package software.blacknode.backend.api.controller.channel.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
+@Getter
+@AllArgsConstructor
+@ToString
 public class ChannelsBatchFetchRequest extends BatchFetchRequest {
 
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteClaimRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteClaimRequest.java
@@ -1,11 +1,14 @@
 package software.blacknode.backend.api.controller.invite.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class InviteClaimRequest extends BaseRequest {
 
 	private String token;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteCreateRequest.java
@@ -1,11 +1,14 @@
 package software.blacknode.backend.api.controller.invite.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class InviteCreateRequest extends BaseRequest{
 
 	private String email;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InvitesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InvitesBatchFetchRequest.java
@@ -1,7 +1,13 @@
 package software.blacknode.backend.api.controller.invite.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
+@Getter
+@AllArgsConstructor
+@ToString
 public class InvitesBatchFetchRequest extends BatchFetchRequest {
 
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/MemberController.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/MemberController.java
@@ -20,8 +20,10 @@ import software.blacknode.backend.api.controller.member.mapper.MemberAddMapper;
 import software.blacknode.backend.api.controller.member.mapper.MemberAssignRoleMapper;
 import software.blacknode.backend.api.controller.member.mapper.MemberAssignedRoleMapper;
 import software.blacknode.backend.api.controller.member.mapper.MemberListMapper;
+import software.blacknode.backend.api.controller.member.mapper.MemberRemoveMapper;
 import software.blacknode.backend.api.controller.member.request.MemberAddRequest;
 import software.blacknode.backend.api.controller.member.request.MemberAssignRoleRequest;
+import software.blacknode.backend.api.controller.member.request.MemberRemoveRequest;
 import software.blacknode.backend.api.controller.member.response.MemberAssignedRoleResponse;
 import software.blacknode.backend.api.controller.member.response.MemberListResponse;
 import software.blacknode.backend.api.controller.organization.annotation.OrganizationHeader;
@@ -40,6 +42,8 @@ import software.blacknode.backend.application.member.usecase.MemberAssignProject
 import software.blacknode.backend.application.member.usecase.MemberAssignedChannelRoleFetchUseCase;
 import software.blacknode.backend.application.member.usecase.MemberAssignedOrganizationRoleFetchUseCase;
 import software.blacknode.backend.application.member.usecase.MemberAssignedProjectRoleFetchUseCase;
+import software.blacknode.backend.application.member.usecase.MemberRemoveFromChannelUseCase;
+import software.blacknode.backend.application.member.usecase.MemberRemoveFromProjectUseCase;
 import software.blacknode.backend.application.member.usecase.MembersInChannelUseCase;
 import software.blacknode.backend.application.member.usecase.MembersInOrganizationUseCase;
 import software.blacknode.backend.application.member.usecase.MembersInProjectUseCase;
@@ -72,6 +76,11 @@ public class MemberController extends BaseController {
 	
 	private final MemberAddToProjectUseCase memberAddToProjectUseCase;
 	private final MemberAddToChannelUseCase memberAddToChannelUseCase;
+	
+	private final MemberRemoveMapper memberRemoveMapper;
+	
+	private final MemberRemoveFromProjectUseCase memberRemoveFromProjectUseCase;
+	private final MemberRemoveFromChannelUseCase memberRemoveFromChannelUseCase;
 	
 	@OrganizationHeader
 	@Operation(summary = "Assign Organization Role to Member", description = "Assigns a specific role to a member within the organization.")
@@ -211,7 +220,7 @@ public class MemberController extends BaseController {
 	@ApiResponse(responseCode = "200", description = "Member added to project successfully.")
 	@PostMapping("/projects/{projectId}/members/add")
 	public ResponseEntity<SuccessResponse> addMemberToProject(@RequestBody MemberAddRequest request, @PathVariable UUID projectId) {
-		var command = memberAddMapper.toProjectCommand(request, HUID.fromUUID(projectId));
+		var command = memberAddMapper.toProjectCommand(request, projectId);
 		
 		memberAddToProjectUseCase.execute(command);
 		
@@ -223,11 +232,35 @@ public class MemberController extends BaseController {
 	@ApiResponse(responseCode = "200", description = "Member added to channel successfully.")
 	@PostMapping("/channels/{channelId}/members/add")
 	public ResponseEntity<SuccessResponse> addMemberToChannel(@RequestBody MemberAddRequest request, @PathVariable UUID channelId) {
-		var command = memberAddMapper.toChannelCommand(request, HUID.fromUUID(channelId));
+		var command = memberAddMapper.toChannelCommand(request, channelId);
 		
 		memberAddToChannelUseCase.execute(command);
 		
 		return SuccessResponse.with("Member added to channel successfully.");
+	}
+	
+	@OrganizationHeader
+	@Operation(summary = "Remove Member from Channel", description = "Removes a member from the specified channel.")
+	@ApiResponse(responseCode = "200", description = "Member removed from channel successfully.")
+	@PostMapping("/projects/{projectId}/members/remove")
+	public ResponseEntity<SuccessResponse> removeMemberFromProject(@RequestBody MemberRemoveRequest request, @PathVariable UUID projectId) {
+		var command = memberRemoveMapper.toProjectCommand(request, projectId);
+		
+		memberRemoveFromProjectUseCase.execute(command);
+		
+		return SuccessResponse.with("Member removed from project successfully.");
+	}
+	
+	@OrganizationHeader
+	@Operation(summary = "Remove Member from Channel", description = "Removes a member from the specified channel.")
+	@ApiResponse(responseCode = "200", description = "Member removed from channel successfully.")
+	@PostMapping("/channels/{channelId}/members/remove")
+	public ResponseEntity<SuccessResponse> removeMemberFromChannel(@RequestBody MemberRemoveRequest request, @PathVariable UUID channelId) {
+		var command = memberRemoveMapper.toChannelCommand(request, channelId);
+		
+		memberRemoveFromChannelUseCase.execute(command);
+		
+		return SuccessResponse.with("Member removed from channel successfully.");
 	}
 	
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberAddMapper.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberAddMapper.java
@@ -1,8 +1,9 @@
 package software.blacknode.backend.api.controller.member.mapper;
 
+import java.util.UUID;
+
 import org.mapstruct.Mapper;
 
-import me.hinsinger.hinz.common.huid.HUID;
 import software.blacknode.backend.api.controller.mapper.ControllerMapper;
 import software.blacknode.backend.api.controller.member.request.MemberAddRequest;
 import software.blacknode.backend.application.member.command.MemberAddToChannelCommand;
@@ -11,8 +12,8 @@ import software.blacknode.backend.application.member.command.MemberAddToProjectC
 @Mapper(componentModel = "spring")
 public interface MemberAddMapper extends ControllerMapper {
 
-	MemberAddToChannelCommand toChannelCommand(MemberAddRequest request, HUID channelId);
+	MemberAddToChannelCommand toChannelCommand(MemberAddRequest request, UUID channelId);
 	
-	MemberAddToProjectCommand toProjectCommand(MemberAddRequest request, HUID projectId);
+	MemberAddToProjectCommand toProjectCommand(MemberAddRequest request, UUID projectId);
 	
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberRemoveMapper.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberRemoveMapper.java
@@ -1,0 +1,18 @@
+package software.blacknode.backend.api.controller.member.mapper;
+
+import java.util.UUID;
+
+import org.mapstruct.Mapper;
+
+import software.blacknode.backend.api.controller.member.request.MemberRemoveRequest;
+import software.blacknode.backend.application.member.command.MemberRemoveFromChannelCommand;
+import software.blacknode.backend.application.member.command.MemberRemoveFromProjectCommand;
+
+@Mapper(componentModel = "spring")
+public interface MemberRemoveMapper {
+
+	MemberRemoveFromChannelCommand toChannelCommand(MemberRemoveRequest request, UUID channelId);
+	
+	MemberRemoveFromProjectCommand toProjectCommand(MemberRemoveRequest request, UUID projectId);
+	
+}

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberRemoveMapper.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/mapper/MemberRemoveMapper.java
@@ -4,12 +4,13 @@ import java.util.UUID;
 
 import org.mapstruct.Mapper;
 
+import software.blacknode.backend.api.controller.mapper.ControllerMapper;
 import software.blacknode.backend.api.controller.member.request.MemberRemoveRequest;
 import software.blacknode.backend.application.member.command.MemberRemoveFromChannelCommand;
 import software.blacknode.backend.application.member.command.MemberRemoveFromProjectCommand;
 
 @Mapper(componentModel = "spring")
-public interface MemberRemoveMapper {
+public interface MemberRemoveMapper extends ControllerMapper {
 
 	MemberRemoveFromChannelCommand toChannelCommand(MemberRemoveRequest request, UUID channelId);
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAddRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAddRequest.java
@@ -2,12 +2,14 @@ package software.blacknode.backend.api.controller.member.request;
 
 import java.util.UUID;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@Builder
+@AllArgsConstructor
+@ToString
 public class MemberAddRequest extends BaseRequest {
 
 	private final UUID memberId;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAssignRoleRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAssignRoleRequest.java
@@ -2,12 +2,14 @@ package software.blacknode.backend.api.controller.member.request;
 
 import java.util.UUID;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@Builder
+@AllArgsConstructor
+@ToString
 public class MemberAssignRoleRequest extends BaseRequest {
 
 	private final UUID roleId;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberRemoveRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberRemoveRequest.java
@@ -1,0 +1,17 @@
+package software.blacknode.backend.api.controller.member.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import software.blacknode.backend.api.controller.request.BaseRequest;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class MemberRemoveRequest extends BaseRequest {
+
+	private UUID memberId;
+	
+}

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/organization/request/OrganizationPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/organization/request/OrganizationPatchRequest.java
@@ -2,10 +2,12 @@ package software.blacknode.backend.api.controller.organization.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
 @AllArgsConstructor
+@ToString
 public class OrganizationPatchRequest extends PatchRequest {
 
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/profile/request/ProfilesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/profile/request/ProfilesBatchFetchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.profile.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ProfilesBatchFetchRequest extends BatchFetchRequest{
 
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectCreateRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.project.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ProjectCreateRequest extends BaseRequest {
 	
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectPatchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.project.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ProjectPatchRequest extends PatchRequest {
 	
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectsBatchFetchRequest.java
@@ -1,7 +1,15 @@
 package software.blacknode.backend.api.controller.project.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
+@Getter
+@AllArgsConstructor
+@ToString
 public class ProjectsBatchFetchRequest extends BatchFetchRequest {
 
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RoleCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RoleCreateRequest.java
@@ -2,12 +2,15 @@ package software.blacknode.backend.api.controller.role.request;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class RoleCreateRequest extends BaseRequest {
 
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolePatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolePatchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.role.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class RolePatchRequest extends PatchRequest {
 
 	private String name;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolesBatchFetchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.role.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class RolesBatchFetchRequest extends BatchFetchRequest {
 
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/setup/request/InitialSetupRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/setup/request/InitialSetupRequest.java
@@ -1,13 +1,16 @@
 package software.blacknode.backend.api.controller.setup.request;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class InitialSetupRequest extends BaseRequest {
 
 	private String organizationName;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskAssignMemberRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskAssignMemberRequest.java
@@ -2,12 +2,15 @@ package software.blacknode.backend.api.controller.task.assign.request;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TaskAssignMemberRequest extends BaseRequest {
 	
 	private UUID memberId;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskUnassignMemberRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskUnassignMemberRequest.java
@@ -2,12 +2,15 @@ package software.blacknode.backend.api.controller.task.assign.request;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@Builder
+@AllArgsConstructor
+@ToString
 public class TaskUnassignMemberRequest extends BaseRequest {
 
 	private UUID memberId;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsBatchFetchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.task.assign.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TasksAssignsBatchFetchRequest extends BatchFetchRequest {
 	
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfMembersRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfMembersRequest.java
@@ -3,12 +3,15 @@ package software.blacknode.backend.api.controller.task.assign.request;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TasksAssignsOfMembersRequest extends BaseRequest {
 
 	private List<UUID> memberIds;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfTasksRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfTasksRequest.java
@@ -3,12 +3,15 @@ package software.blacknode.backend.api.controller.task.assign.request;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TasksAssignsOfTasksRequest extends BaseRequest {
 
 	private List<UUID> taskIds;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskCreateRequest.java
@@ -2,12 +2,15 @@ package software.blacknode.backend.api.controller.task.request;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TaskCreateRequest extends BaseRequest {
 
 	private String title;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskPatchRequest.java
@@ -2,12 +2,15 @@ package software.blacknode.backend.api.controller.task.request;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TaskPatchRequest extends PatchRequest {
 
 	private String title;

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TasksBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TasksBatchFetchRequest.java
@@ -1,11 +1,16 @@
 package software.blacknode.backend.api.controller.task.request;
 
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class TasksBatchFetchRequest extends BatchFetchRequest {
 	
 }

--- a/backend/blacknode-software-backend-application/pom.xml
+++ b/backend/blacknode-software-backend-application/pom.xml
@@ -37,4 +37,20 @@
 			<artifactId>blacknode-software-backend-shared</artifactId>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/health/usecase/HealthFetchUseCase.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/health/usecase/HealthFetchUseCase.java
@@ -3,6 +3,7 @@ package software.blacknode.backend.application.health.usecase;
 import java.util.Optional;
 
 import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.stereotype.Service;
 
 import lombok.Builder;

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/command/MemberRemoveFromChannelCommand.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/command/MemberRemoveFromChannelCommand.java
@@ -1,0 +1,21 @@
+package software.blacknode.backend.application.member.command;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import me.hinsinger.hinz.common.huid.HUID;
+import software.blacknode.backend.application.command.ExecutionCommand;
+
+@Getter
+@Builder
+@ToString
+public class MemberRemoveFromChannelCommand implements ExecutionCommand {
+
+	@NonNull
+	private final HUID memberId;
+	
+	@NonNull
+	private final HUID channelId;
+	
+}

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/command/MemberRemoveFromProjectCommand.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/command/MemberRemoveFromProjectCommand.java
@@ -1,0 +1,21 @@
+package software.blacknode.backend.application.member.command;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import me.hinsinger.hinz.common.huid.HUID;
+import software.blacknode.backend.application.command.ExecutionCommand;
+
+@Getter
+@Builder
+@ToString
+public class MemberRemoveFromProjectCommand implements ExecutionCommand {
+	
+	@NonNull
+	private final HUID memberId;
+
+	@NonNull
+	private final HUID projectId;
+	
+}

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/usecase/MemberRemoveFromChannelUseCase.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/usecase/MemberRemoveFromChannelUseCase.java
@@ -1,0 +1,51 @@
+package software.blacknode.backend.application.member.usecase;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import software.blacknode.backend.application.access.impl.ChannelAccessControl;
+import software.blacknode.backend.application.access.level.AccessLevel;
+import software.blacknode.backend.application.channel.ChannelService;
+import software.blacknode.backend.application.member.MemberService;
+import software.blacknode.backend.application.member.command.MemberRemoveFromChannelCommand;
+import software.blacknode.backend.application.shared.SharedDeletionService;
+import software.blacknode.backend.application.usecase.ExecutionUseCase;
+import software.blacknode.backend.domain.session.context.holder.SessionContextHolder;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRemoveFromChannelUseCase implements ExecutionUseCase<MemberRemoveFromChannelCommand> {
+
+	private final ChannelAccessControl channelAccessControl;
+	
+	private final ChannelService channelService;
+	
+	private final MemberService memberService;
+	
+	private final SharedDeletionService sharedDeletionService;
+	
+	private final SessionContextHolder sessionContextHolder;
+	
+	@Override
+	@Transactional
+	public void execute(MemberRemoveFromChannelCommand command) {
+		sessionContextHolder.ensureOrganizationScoped();
+		
+		var organizationId = sessionContextHolder.getOrganizationIdOrThrow();
+		var memberId = sessionContextHolder.getMemberIdOrThrow();
+		
+		var channelId = command.getChannelId();
+		var channel = channelService.getOrThrow(organizationId, channelId);
+		
+		var targetMemberId = command.getMemberId();
+		var targetMember = memberService.getOrThrow(organizationId, targetMemberId);
+		
+		channelAccessControl.ensureMemberHasChannelAccess(memberId, channel, AccessLevel.MANAGE);
+		
+		channelAccessControl.ensureMemberHasChannelAccess(targetMember, channel, AccessLevel.READ);
+		
+		sharedDeletionService.deleteMemberFromChannel(organizationId, targetMemberId, channelId);
+	}
+
+}

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/usecase/MemberRemoveFromProjectUseCase.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/member/usecase/MemberRemoveFromProjectUseCase.java
@@ -1,0 +1,50 @@
+package software.blacknode.backend.application.member.usecase;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import software.blacknode.backend.application.access.impl.ProjectAccessControl;
+import software.blacknode.backend.application.access.level.AccessLevel;
+import software.blacknode.backend.application.member.MemberService;
+import software.blacknode.backend.application.member.command.MemberRemoveFromProjectCommand;
+import software.blacknode.backend.application.project.ProjectService;
+import software.blacknode.backend.application.shared.SharedDeletionService;
+import software.blacknode.backend.application.usecase.ExecutionUseCase;
+import software.blacknode.backend.domain.session.context.holder.SessionContextHolder;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRemoveFromProjectUseCase implements ExecutionUseCase<MemberRemoveFromProjectCommand> {
+
+	private final ProjectAccessControl projectAccessControl;
+	
+	private final ProjectService projectService;
+	
+	private final MemberService memberService;
+	
+	private final SharedDeletionService sharedDeletionService;
+	
+	private final SessionContextHolder sessionContextHolder;
+	
+	@Override
+	@Transactional
+	public void execute(MemberRemoveFromProjectCommand command) {
+		sessionContextHolder.ensureOrganizationScoped();
+		
+		var organizationId = sessionContextHolder.getOrganizationIdOrThrow();
+		var memberId = sessionContextHolder.getMemberIdOrThrow();
+		
+		var projectId = command.getProjectId();
+		var project = projectService.getOrThrow(organizationId, projectId);
+		
+		var targetMemberId = command.getMemberId();
+		var targetMember = memberService.getOrThrow(organizationId, targetMemberId);
+		
+		projectAccessControl.ensureMemberHasProjectAccess(memberId, project, AccessLevel.MANAGE);
+		
+		projectAccessControl.ensureMemberHasProjectAccess(targetMember, project, AccessLevel.READ);
+		
+		sharedDeletionService.deleteMemberFromProject(organizationId, targetMemberId, projectId);
+	}
+}

--- a/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/task/assign/TaskAssignService.java
+++ b/backend/blacknode-software-backend-application/src/main/java/software/blacknode/backend/application/task/assign/TaskAssignService.java
@@ -38,7 +38,7 @@ public class TaskAssignService {
 	}
 	
 	public void delete(HUID organizationId, HUID id, DeletionMeta meta) {
-		var taskAssign = getOrThrow(organizationId, organizationId);
+		var taskAssign = getOrThrow(organizationId, id);
 		
 		taskAssign.delete(meta);
 		

--- a/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/association/meta/delete/impl/MemberAssociationCascadeDeletionMeta.java
+++ b/backend/blacknode-software-backend-domain/src/main/java/software/blacknode/backend/domain/member/association/meta/delete/impl/MemberAssociationCascadeDeletionMeta.java
@@ -1,0 +1,11 @@
+package software.blacknode.backend.domain.member.association.meta.delete.impl;
+
+import lombok.Builder;
+import lombok.Getter;
+import software.blacknode.backend.domain.member.association.meta.delete.MemberAssociationDeletionMeta;
+
+@Getter
+@Builder
+public class MemberAssociationCascadeDeletionMeta implements MemberAssociationDeletionMeta {
+
+}


### PR DESCRIPTION
This pull request introduces several improvements to the backend API request and controller layer, mainly focusing on standardizing request DTOs, simplifying member management, and improving code consistency. The most notable changes are the addition of new member removal endpoints and mappers, refactoring of existing mappers to use `UUID` instead of `HUID`, and making all request classes easier to debug and use by adding Lombok annotations.

**Member management enhancements:**

* Added new endpoints in `MemberController` to remove members from projects and channels, along with corresponding request (`MemberRemoveRequest`) and mapper (`MemberRemoveMapper`) classes. This enables proper member removal functionality via the API. [[1]](diffhunk://#diff-c47aace7382fd3e415d754a6523752f9e950f961c3142d3e35d5f4e82075e1c0R45-R46) [[2]](diffhunk://#diff-c47aace7382fd3e415d754a6523752f9e950f961c3142d3e35d5f4e82075e1c0R80-R84) [[3]](diffhunk://#diff-70755fc15a622115d5648f343726a67dbc596895e2740a35830bdc9333289105R1-R17) [[4]](diffhunk://#diff-5c2c6ce7d1a3930db6f45345f096424a9cc76e58293af20584f62e756069ccfbR1-R19) [[5]](diffhunk://#diff-c47aace7382fd3e415d754a6523752f9e950f961c3142d3e35d5f4e82075e1c0L226-R265)
* Refactored `MemberAddMapper` to use `UUID` instead of `HUID` for project and channel IDs, simplifying integration and reducing coupling to domain-specific ID types. [[1]](diffhunk://#diff-2adbcf7b78873763159feb681730ded2656d0d315ee96b05c6de18b1756b49cdR3-L5) [[2]](diffhunk://#diff-2adbcf7b78873763159feb681730ded2656d0d315ee96b05c6de18b1756b49cdL14-R17) [[3]](diffhunk://#diff-c47aace7382fd3e415d754a6523752f9e950f961c3142d3e35d5f4e82075e1c0L214-R223)

**Request DTO standardization and improvements:**

* Added Lombok `@AllArgsConstructor` and `@ToString` annotations to all request DTOs (e.g., `AccountPatchRequest`, `ChannelCreateRequest`, `InviteCreateRequest`, etc.), making them easier to instantiate and debug. [[1]](diffhunk://#diff-78cb2e2fb815be52381958fe15cb2171aae8d7dbf765870ef8bb9934717f3c0cR5-R10) [[2]](diffhunk://#diff-74784128ea4c5ac2a433a8db0489e847a245ead5d65ce1c9abcd39d17d0c4df7R3-R9) [[3]](diffhunk://#diff-aec7b2b0fc4c2ae506c7a9b740ceeec00dd1db13c5422207455d13b8a3125664R3-R11) [[4]](diffhunk://#diff-46657b080a89ab3b96c8b218f2af32d52b83df744eb06b1689e87effdd523439R3-R11) [[5]](diffhunk://#diff-05f855d41b8238154eb5739394824c7ff88dcbf51455a030d6e82f7be675be11R3-R10) [[6]](diffhunk://#diff-4842229435fc2b7c6bb720a7b4cf64a6f007ba6fdef1a352347ac4cd2454652cR3-R11) [[7]](diffhunk://#diff-be2bea69c1d8cded0219d8e1d461c7c1c0509a7ef1a6904cb09f13b00d760c12R3-R11) [[8]](diffhunk://#diff-338489e9eda70391840b0c86e47f956cf7236e9b5e76ac1f0ddf9a78116dec81R3-R10) [[9]](diffhunk://#diff-6166913598c3b3b791e17e03808874263bb5fb5d36f38bdfb3c0b94b2c7b39afL5-R12) [[10]](diffhunk://#diff-d5b674cadcd850ed9d84ef657e89d0ae71b0bee30ff33fa4c2f85442fd19d76fL5-R12) [[11]](diffhunk://#diff-e2a362a0d3d015b46e244658100bc77e18a32f10e4fb1eb4089d08dcc4db4b1fR5-R10) [[12]](diffhunk://#diff-d1f128a0859bf2cf8ea3397a03c7bd2740b78333d5faca960e327b86f69a3762R3-R13) [[13]](diffhunk://#diff-2f113c5eeaf3aca57b0b22e19f3bea281d877838a3879634a958d6a94fbdd9c4R3-R13) [[14]](diffhunk://#diff-f1d6b6f5bb04bae3dc17bd07f1210308c30e42bedc4db0d877d9ad5bbbad6803R3-R13) [[15]](diffhunk://#diff-5011d2d485ea584cb5b5439f876d41b3efcfcc795b76455e0364bd11c3a5092eR3-R12) [[16]](diffhunk://#diff-38c8a90efd20a5d8df1ba256c2399d9b19f12cd4350fffa2b58687abcd7ac7d8R5-R13)

These changes improve maintainability, consistency, and the developer experience when working with the API layer.