### PR TITLE
Request parsing

### DIFF
--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/account/request/AccountPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/account/request/AccountPatchRequest.java
@@ -1,12 +1,12 @@
 package software.blacknode.backend.api.controller.account.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class AccountPatchRequest extends PatchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelCreateRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ChannelCreateRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelPatchRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ChannelPatchRequest extends PatchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/channel/request/ChannelsBatchFetchRequest.java
@@ -1,12 +1,12 @@
 package software.blacknode.backend.api.controller.channel.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ChannelsBatchFetchRequest extends BatchFetchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteClaimRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteClaimRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class InviteClaimRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InviteCreateRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class InviteCreateRequest extends BaseRequest{
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InvitesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/invite/request/InvitesBatchFetchRequest.java
@@ -2,11 +2,12 @@ package software.blacknode.backend.api.controller.invite.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class InvitesBatchFetchRequest extends BatchFetchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAddRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAddRequest.java
@@ -4,14 +4,15 @@ import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class MemberAddRequest extends BaseRequest {
 
-	private final UUID memberId;
+	private UUID memberId;
 	
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAssignRoleRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberAssignRoleRequest.java
@@ -4,14 +4,15 @@ import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class MemberAssignRoleRequest extends BaseRequest {
 
-	private final UUID roleId;
+	private UUID roleId;
 	
 }

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberRemoveRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/member/request/MemberRemoveRequest.java
@@ -4,11 +4,12 @@ import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class MemberRemoveRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/organization/request/OrganizationPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/organization/request/OrganizationPatchRequest.java
@@ -2,11 +2,12 @@ package software.blacknode.backend.api.controller.organization.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class OrganizationPatchRequest extends PatchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/profile/request/ProfilesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/profile/request/ProfilesBatchFetchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ProfilesBatchFetchRequest extends BatchFetchRequest{
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectCreateRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ProjectCreateRequest extends BaseRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectPatchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ProjectPatchRequest extends PatchRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/project/request/ProjectsBatchFetchRequest.java
@@ -4,11 +4,12 @@ import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ProjectsBatchFetchRequest extends BatchFetchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RoleCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RoleCreateRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class RoleCreateRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolePatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolePatchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class RolePatchRequest extends PatchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolesBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/role/request/RolesBatchFetchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class RolesBatchFetchRequest extends BatchFetchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/setup/request/InitialSetupRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/setup/request/InitialSetupRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class InitialSetupRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskAssignMemberRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskAssignMemberRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TaskAssignMemberRequest extends BaseRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskUnassignMemberRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TaskUnassignMemberRequest.java
@@ -5,11 +5,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TaskUnassignMemberRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsBatchFetchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TasksAssignsBatchFetchRequest extends BatchFetchRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfMembersRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfMembersRequest.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TasksAssignsOfMembersRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfTasksRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/assign/request/TasksAssignsOfTasksRequest.java
@@ -3,14 +3,13 @@ package software.blacknode.backend.api.controller.task.assign.request;
 import java.util.List;
 import java.util.UUID;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TasksAssignsOfTasksRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskCreateRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskCreateRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BaseRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TaskCreateRequest extends BaseRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskPatchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TaskPatchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.PatchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TaskPatchRequest extends PatchRequest {
 

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TasksBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/task/request/TasksBatchFetchRequest.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class TasksBatchFetchRequest extends BatchFetchRequest {
 	

--- a/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/view/request/ViewsBatchFetchRequest.java
+++ b/backend/blacknode-software-backend-api/src/main/java/software/blacknode/backend/api/controller/view/request/ViewsBatchFetchRequest.java
@@ -1,9 +1,13 @@
 package software.blacknode.backend.api.controller.view.request;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import software.blacknode.backend.api.controller.request.BatchFetchRequest;
 
+@Getter
 @NoArgsConstructor
+@ToString
 public class ViewsBatchFetchRequest extends BatchFetchRequest {
 
 }


### PR DESCRIPTION
This pull request refactors multiple request classes across the backend API to improve their instantiation and flexibility. The main change is replacing the use of Lombok's `@AllArgsConstructor` with `@NoArgsConstructor` in various request classes, allowing for easier deserialization and object creation without requiring all arguments up front. In a few member-related request classes, fields previously declared as `final` are now mutable, further supporting this change.

### Refactoring for request object instantiation

* Replaced `@AllArgsConstructor` with `@NoArgsConstructor` in all request DTO classes, including account, channel, invite, member, organization, profile, project, role, and setup requests, to allow for no-argument construction and easier deserialization. [[1]](diffhunk://#diff-78cb2e2fb815be52381958fe15cb2171aae8d7dbf765870ef8bb9934717f3c0cL3-R9) [[2]](diffhunk://#diff-aec7b2b0fc4c2ae506c7a9b740ceeec00dd1db13c5422207455d13b8a3125664L10-R10) [[3]](diffhunk://#diff-46657b080a89ab3b96c8b218f2af32d52b83df744eb06b1689e87effdd523439L10-R10) [[4]](diffhunk://#diff-05f855d41b8238154eb5739394824c7ff88dcbf51455a030d6e82f7be675be11L3-R9) [[5]](diffhunk://#diff-4842229435fc2b7c6bb720a7b4cf64a6f007ba6fdef1a352347ac4cd2454652cL10-R10) [[6]](diffhunk://#diff-be2bea69c1d8cded0219d8e1d461c7c1c0509a7ef1a6904cb09f13b00d760c12L10-R10) [[7]](diffhunk://#diff-338489e9eda70391840b0c86e47f956cf7236e9b5e76ac1f0ddf9a78116dec81R5-R10) [[8]](diffhunk://#diff-6166913598c3b3b791e17e03808874263bb5fb5d36f38bdfb3c0b94b2c7b39afR7-R16) [[9]](diffhunk://#diff-d5b674cadcd850ed9d84ef657e89d0ae71b0bee30ff33fa4c2f85442fd19d76fR7-R16) [[10]](diffhunk://#diff-70755fc15a622115d5648f343726a67dbc596895e2740a35830bdc9333289105R7-R12) [[11]](diffhunk://#diff-e2a362a0d3d015b46e244658100bc77e18a32f10e4fb1eb4089d08dcc4db4b1fR5-R10) [[12]](diffhunk://#diff-d1f128a0859bf2cf8ea3397a03c7bd2740b78333d5faca960e327b86f69a3762L12-R12) [[13]](diffhunk://#diff-2f113c5eeaf3aca57b0b22e19f3bea281d877838a3879634a958d6a94fbdd9c4L12-R12) [[14]](diffhunk://#diff-f1d6b6f5bb04bae3dc17bd07f1210308c30e42bedc4db0d877d9ad5bbbad6803L12-R12) [[15]](diffhunk://#diff-5011d2d485ea584cb5b5439f876d41b3efcfcc795b76455e0364bd11c3a5092eR7-R12) [[16]](diffhunk://#diff-38c8a90efd20a5d8df1ba256c2399d9b19f12cd4350fffa2b58687abcd7ac7d8L12-R12) [[17]](diffhunk://#diff-277ac331f7c0af89905afa0cf7604d0f91ba87e7377f214dc18c31912ab9f11bL12-R12) [[18]](diffhunk://#diff-078647d8e8438cdba75d2bdb4de2eab321751a9ecbd735d8af3589f5e3084ab6L12-R12) [[19]](diffhunk://#diff-d0a58f5888d564b5a6a2a82365d3bb60cfd19ebfe592c28dbd18e0a456d45405L12-R12) [[20]](diffhunk://#diff-6274727f1b6f0b821082a15bae2c7ba20cef7eae37860a893fda942a0e3325b5L12-R12)

### Field mutability changes

* Changed `memberId` in `MemberAddRequest` and `roleId` in `MemberAssignRoleRequest` from `final` to mutable fields to support no-argument constructors and setter-based initialization. [[1]](diffhunk://#diff-6166913598c3b3b791e17e03808874263bb5fb5d36f38bdfb3c0b94b2c7b39afR7-R16) [[2]](diffhunk://#diff-d5b674cadcd850ed9d84ef657e89d0ae71b0bee30ff33fa4c2f85442fd19d76fR7-R16)

These changes standardize the request object pattern, making them more compatible with frameworks that require no-argument constructors (such as Jackson or other serialization libraries), and improve maintainability and testability of the codebase.